### PR TITLE
Merge back for 5.0 RC release

### DIFF
--- a/BuildVersion.xml
+++ b/BuildVersion.xml
@@ -2,8 +2,8 @@
 This file is updated on a public release to set the next build that pre-releases will increment to
 -->
 <BuildVersionData
-    BuildMajor = "5"
+    BuildMajor = "6"
     BuildMinor = "0"
     BuildPatch = "0"
-    PreReleaseName = "rc"
+    PreReleaseName = "alpha"
 />

--- a/BuildVersion.xml
+++ b/BuildVersion.xml
@@ -5,5 +5,5 @@ This file is updated on a public release to set the next build that pre-releases
     BuildMajor = "5"
     BuildMinor = "0"
     BuildPatch = "0"
-    PreReleaseName = "alpha"
+    PreReleaseName = "rc"
 />

--- a/OneFlow/Publish-Release.ps1
+++ b/OneFlow/Publish-Release.ps1
@@ -36,7 +36,7 @@ Write-Information 'Fetching from official repository'
 Invoke-External git fetch $officialRemoteName
 
 Write-Information "Switching to release branch [$officialReleaseBranch]"
-Invoke-External git switch '-c' $releasebranch $officialReleaseBranch
+Invoke-External git switch '-C' $releasebranch $officialReleaseBranch
 
 Write-Information 'Creating tag of this branch as the release'
 Invoke-External git tag $tagname '-m' "Official release: $tagname"


### PR DESCRIPTION
Updated publish script to reset existing branch instead of fail
Bumped version to 6.0 alpha as that's the next release. Any patches to the RC are done against the release tag